### PR TITLE
docs(templates): fix the issue report & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/A.md
+++ b/.github/ISSUE_TEMPLATE/A.md
@@ -7,7 +7,7 @@ labels: ''
 assignees: ''
 
 ---
-Please checkout our [documentation](https://docs.bugsnag.com/platforms/go/) for guides, references and tutorials.
+Please checkout our [documentation](https://docs.bugsnag.com/platforms/go/gin) for guides, references and tutorials.
 
 If you have questions about your integration please contact us at [support@bugsnag.com](mailto:support@bugsnag.com).
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,7 @@ A clear and concise description of what the bug is.
 4. See error
 
 ### Environment
+* Bugsnag Go version:
 * Bugsnag Go Gin version:
 * Go version:
 * Gin framework version:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ A clear and concise description of what the bug is.
 4. See error
 
 ### Environment
-* Bugsnag version:
+* Bugsnag Go Gin version:
 * Go version:
 * Gin framework version:
 

--- a/.github/support.md
+++ b/.github/support.md
@@ -9,6 +9,7 @@ When contacting support, please include as much information as necessary, includ
 - steps to reproduce
 - expected/actual behaviour 
 
+* Bugsnag Go version:
 * Bugsnag Go Gin version:
 * Go version:
 * Gin framework version:

--- a/.github/support.md
+++ b/.github/support.md
@@ -1,5 +1,5 @@
 ## Are you having trouble getting started?
-If you haven't already, please checkout our [documentation](https://docs.bugsnag.com/platforms/go/) for guides, references and tutorials.
+If you haven't already, please checkout our [documentation](https://docs.bugsnag.com/platforms/go/gin) for guides, references and tutorials.
 
 Or, if you wish you can [contact us directly](mailto:support@bugsnag.com) for assistance on integrating Bugsnag into your application, troubleshooting an issue or a question about our supported features.
 
@@ -9,14 +9,9 @@ When contacting support, please include as much information as necessary, includ
 - steps to reproduce
 - expected/actual behaviour 
 
-* Bugsnag version:
+* Bugsnag Go Gin version:
 * Go version:
-* Integration framework version:
-    * Martini:
-    * Negroni:
-    * net/http:
-    * Revel:
-    * Other:
+* Gin framework version:
 
 ## Bug or Feature Requests
 If you would like to raise a bug or feature request please do so by creating a [New Issue](https://github.com/bugsnag/bugsnag-go-gin/issues/new/choose) and selecting bug or feature.


### PR DESCRIPTION
## Goal

Bringing templates inline with our base config, to match other Go repos.